### PR TITLE
Fix actors recreated have shorter first frames of animation

### DIFF
--- a/com/stencyl/graphics/SheetAnimation.hx
+++ b/com/stencyl/graphics/SheetAnimation.hx
@@ -127,8 +127,13 @@ class SheetAnimation extends Sprite implements AbstractAnimation
 			frame = 0;
 		}
 		
-		frameIndex = frame;
-		needsUpdate = true;
+		if(frame != frameIndex)
+		{
+			frameIndex = frame;
+			needsUpdate = true;
+		}
+
+		timer = 0;
 		finished = false;
 		
 		//Q: should we be altering the shared instance?


### PR DESCRIPTION
Issue here: http://community.stencyl.com/index.php?issue=10.0. Key line is 'timer = 0;'