### PR TITLE
Fix tile display when scene tile size is different from tileset tile size

### DIFF
--- a/com/stencyl/models/scene/TileLayer.hx
+++ b/com/stencyl/models/scene/TileLayer.hx
@@ -371,6 +371,19 @@ class TileLayer extends Sprite
 					pixels = t.pixels;
 				}
 				
+				//Draw correctly if scene tile size and tileset tile size are different
+				if (tw != t.parent.tileWidth){		
+					var scaleX = tw/t.parent.tileWidth;
+					var scaleY = th/t.parent.tileHeight;
+					var data = new BitmapData(Std.int(t.parent.framesAcross * t.parent.tileWidth * scaleX),Std.int(t.parent.framesDown * t.parent.tileHeight * scaleY));
+					var matrix:Matrix = new Matrix();
+					
+					matrix.scale(scaleX, scaleY);
+					data.fillRect(bitmapData.rect, 0);
+					data.draw(pixels, matrix);
+					pixels = data.clone();
+				}
+				
 				#if (flash || js)
 				flashPoint.x = px * Engine.SCALE;
 				flashPoint.y = py * Engine.SCALE;

--- a/com/stencyl/models/scene/TileLayer.hx
+++ b/com/stencyl/models/scene/TileLayer.hx
@@ -370,7 +370,8 @@ class TileLayer extends Sprite
 				{
 					pixels = t.pixels;
 				}
-				
+
+				#if (flash || js)				
 				//Draw correctly if scene tile size and tileset tile size are different
 				if (tw != t.parent.tileWidth){		
 					var scaleX = tw/t.parent.tileWidth;
@@ -384,7 +385,6 @@ class TileLayer extends Sprite
 					pixels = data.clone();
 				}
 				
-				#if (flash || js)
 				flashPoint.x = px * Engine.SCALE;
 				flashPoint.y = py * Engine.SCALE;
 				
@@ -404,6 +404,28 @@ class TileLayer extends Sprite
 				if(t.data == null)
 				{
 					t.parent.data[2] = t.parent.sheetMap.get(t.tileID);
+					
+					if (tw != t.parent.tileWidth){		
+						var scaleX = tw/t.parent.tileWidth;
+						var scaleY = th/t.parent.tileHeight;
+						var data = new BitmapData(Std.int(t.parent.framesAcross * t.parent.tileWidth * scaleX),Std.int(t.parent.framesDown * t.parent.tileHeight * scaleY), true);
+						var matrix:Matrix = new Matrix();
+							
+						matrix.scale(scaleX, scaleY);
+						data.fillRect(data.rect, 0);
+						data.draw(pixels, matrix);
+						pixels = data.clone();
+						t.parent.tilesheet = new Tilesheet(pixels);
+						for(tile in t.parent.tiles)
+						{
+							if(tile == null)
+							{
+								continue;
+							}
+							var r = new Rectangle(Math.floor(tile.frameIndex % t.parent.framesAcross) * tw * Engine.SCALE, Math.floor(tile.frameIndex / t.parent.framesAcross) * th * Engine.SCALE, tw * Engine.SCALE, th * Engine.SCALE);
+							t.parent.tilesheet.addTileRect(r);
+						}
+					}
 					
 					if(t.parent.tilesheet != null)
 					{


### PR DESCRIPTION
I am unsure how efficient this change is currently as I haven't benchmarked it. I have currently tested in flash and Windows, and since it could break things I suggest testing in a couple of other build modes before merging.

 In the scene designer when scene tile size is different from tileset tile size the scene is displayed as shown below:
![in scene designer](https://cloud.githubusercontent.com/assets/13985596/10823439/a57e38fe-7e53-11e5-9f91-955f8abc998a.png)
However, in the game the rendering is inconsistent (as shown below). This could be confusing, especially for new users.
![old](https://cloud.githubusercontent.com/assets/13985596/10823443/a8832e06-7e53-11e5-9d2b-fefdb5e148f9.png)
My changes change how it is displayed, so now it is displayed like this. 
![new](https://cloud.githubusercontent.com/assets/13985596/10823440/a7015260-7e53-11e5-81c1-363461539e5c.png)



