### PR TITLE
Allow repeating backgrounds to animate.

### DIFF
--- a/com/stencyl/models/scene/ScrollingBitmap.hx
+++ b/com/stencyl/models/scene/ScrollingBitmap.hx
@@ -171,6 +171,9 @@ class ScrollingBitmap extends Sprite
 	
 	public function resetPositions()
 	{
+		cacheWidth = image1.width;
+		cacheHeight = image1.height;
+		
 		if (xPos < -cacheWidth)
 		{
 			xPos = xPos % cacheWidth;

--- a/com/stencyl/models/scene/layers/BackgroundLayer.hx
+++ b/com/stencyl/models/scene/layers/BackgroundLayer.hx
@@ -197,24 +197,58 @@ class BackgroundLayer extends RegularLayer
 			
 			if (Std.is(bgChild, ScrollingBitmap))
 			{
+				
+				model.img = model.frames[currIndex];
+				var cacheIndex = currIndex;
+				
+				if(model.repeats)
+				{
+					model.drawRepeated(this, Std.int(Engine.screenWidth * Engine.SCALE), Std.int(Engine.screenHeight * Engine.SCALE));
+				}
+				
+				currIndex = cacheIndex;
+				
 				var b:Bitmap = bgChild.image1;
-				b.bitmapData = model.frames[currIndex];				
+				b.bitmapData = model.img;	
+
+				var cacheWidth = b.width;
+				var cacheHeight = b.height;
+
 				b = bgChild.image2;
-				b.bitmapData = model.frames[currIndex];		
+				b.bitmapData = model.img;	
+				bgChild.image2.x = bgChild.image1.x-cacheWidth;	
+				
 				b = bgChild.image3;
-				b.bitmapData = model.frames[currIndex];
+				b.bitmapData = model.img;
+				b.x = bgChild.image1.x+cacheWidth;
+				
 				b = bgChild.image4;
-				b.bitmapData = model.frames[currIndex];
+				b.bitmapData = model.img;
+			    b.x = bgChild.image1.x-cacheWidth;
+				b.y = bgChild.image1.y-cacheHeight;
+				
 				b = bgChild.image5;
-				b.bitmapData = model.frames[currIndex];
+				b.bitmapData = model.img;
+				b.y = bgChild.image1.y-cacheHeight;
+				
 				b = bgChild.image6;
-				b.bitmapData = model.frames[currIndex];
+				b.bitmapData = model.img;
+		        b.x = bgChild.image1.x+cacheWidth;
+				b.y = bgChild.image1.y-cacheHeight;
+				
 				b = bgChild.image7;
-				b.bitmapData = model.frames[currIndex];
+				b.bitmapData = model.img;
+		        b.x = bgChild.image1.x-cacheWidth;
+				b.y = bgChild.image1.y+cacheHeight;
+				
 				b = bgChild.image8;
-				b.bitmapData = model.frames[currIndex];
+				b.bitmapData = model.img;
+				b.y = bgChild.image1.y+cacheHeight;
+				
 				b = bgChild.image9;
-				b.bitmapData = model.frames[currIndex];				
+				b.bitmapData = model.img;	
+		        b.x = bgChild.image1.x+cacheWidth;
+				b.y = bgChild.image1.y+cacheHeight;
 			}
 			
 			else


### PR DESCRIPTION
This will allow backgrounds which repeat to successfully animate now whereas before they would incorrectly tile each frame after the first one, leading to little of the background being shown.