### PR TITLE
Multiple changes to how scrolling repeated backgrounds are rendered.

### DIFF
--- a/com/stencyl/models/background/ImageBackground.hx
+++ b/com/stencyl/models/background/ImageBackground.hx
@@ -63,7 +63,7 @@ class ImageBackground extends Resource implements Background
 	}		
 	
 	//TODO: drawTiles on CPP
-	public function drawRepeated(bitmap:BackgroundLayer, screenWidth:Int, screenHeight:Int)
+	public function drawRepeated(?bitmap:BackgroundLayer, screenWidth:Int, screenHeight:Int)
 	{
 		var tw:Float = img.width;
 		var th:Float = img.height;
@@ -96,7 +96,7 @@ class ImageBackground extends Resource implements Background
 			}
 		}
 		
-		bitmap.setImage(texture);
+		//bitmap.setImage(texture);
 		this.img = texture;
 		
 		repeated = true;
@@ -142,7 +142,17 @@ class ImageBackground extends Resource implements Background
 		
 		for(i in 0...frameData.length)
 		{
-			this.frames.push(frameData[i]);				
+			if(this.repeats)
+			{
+				this.img = frameData[i];
+				drawRepeated(Std.int(Engine.screenWidth * Engine.SCALE), Std.int(Engine.screenHeight * Engine.SCALE));
+				this.frames.push(this.img);
+			} 
+			else 
+			{
+				this.frames.push(frameData[i]);			
+			}	
+		
 		}
 		
 		this.img = frames[0];

--- a/com/stencyl/models/scene/ScrollingBitmap.hx
+++ b/com/stencyl/models/scene/ScrollingBitmap.hx
@@ -36,14 +36,16 @@ class ScrollingBitmap extends Sprite
 	public var parallaxY:Float;
 	
 	public var backgroundID:Int;
+	public var repeats:Bool;
 	
-	public function new(img:Dynamic, dx:Float, dy:Float, px:Float=0, py:Float=0, ID:Int=0) 
+	public function new(img:Dynamic, dx:Float, dy:Float, px:Float=0, py:Float=0, ID:Int=0, repeats:Bool = true) 
 	{
 		super();
 		
 		curStep = 0;
 	
 		running = true;
+		this.repeats = repeats;
 		
 		image1 = new Bitmap(img);
 		addChild(image1);
@@ -51,45 +53,48 @@ class ScrollingBitmap extends Sprite
 		cacheWidth = image1.width;
 		cacheHeight = image1.height;
         
-		image2 = new Bitmap(img);
-        image2.x = image1.x-cacheWidth;
-		addChild(image2);
-        
-        image3 = new Bitmap(img);
-        image3.x = image1.x+cacheWidth;
-		addChild(image3);
-        
-        //
-        
-        image4 = new Bitmap(img);
-        image4.x = image1.x-cacheWidth;
-        image4.y = image1.y-cacheHeight;
-		addChild(image4);
-        
-        image5 = new Bitmap(img);
-        image5.y = image1.y-cacheHeight;
-		addChild(image5);
-        
-        image6 = new Bitmap(img);
-        image6.x = image1.x+cacheWidth;
-        image6.y = image1.y-cacheHeight;
-		addChild(image6);
-        
-        //
-        
-        image7 = new Bitmap(img);
-        image7.x = image1.x-cacheWidth;
-        image7.y = image1.y+cacheHeight;
-		addChild(image7);
-        
-        image8 = new Bitmap(img);
-        image8.y = image1.y+cacheHeight;
-		addChild(image8);
-        
-        image9 = new Bitmap(img);
-        image9.x = image1.x+cacheWidth;
-        image9.y = image1.y+cacheHeight;
-		addChild(image9);
+		if (repeats)
+		{
+			image2 = new Bitmap(img);
+			image2.x = image1.x-cacheWidth;
+			addChild(image2);
+			
+			image3 = new Bitmap(img);
+			image3.x = image1.x+cacheWidth;
+			addChild(image3);
+			
+			//
+			
+			image4 = new Bitmap(img);
+			image4.x = image1.x-cacheWidth;
+			image4.y = image1.y-cacheHeight;
+			addChild(image4);
+			
+			image5 = new Bitmap(img);
+			image5.y = image1.y-cacheHeight;
+			addChild(image5);
+			
+			image6 = new Bitmap(img);
+			image6.x = image1.x+cacheWidth;
+			image6.y = image1.y-cacheHeight;
+			addChild(image6);
+			
+			//
+			
+			image7 = new Bitmap(img);
+			image7.x = image1.x-cacheWidth;
+			image7.y = image1.y+cacheHeight;
+			addChild(image7);
+			
+			image8 = new Bitmap(img);
+			image8.y = image1.y+cacheHeight;
+			addChild(image8);
+			
+			image9 = new Bitmap(img);
+			image9.x = image1.x+cacheWidth;
+			image9.y = image1.y+cacheHeight;
+			addChild(image9);
+		}
 		
 		xP = 0;
 		yP = 0;
@@ -139,15 +144,18 @@ class ScrollingBitmap extends Sprite
 			xP += xVelocity / 10.0 * Engine.SCALE;
 			yP += yVelocity / 10.0 * Engine.SCALE;
 			
-			if(xP < -width || xP > width)
-	        {
-	            xP = 0;
-	        }
-	        
-	        if(yP < -height || yP > height)
-	        {
-	            yP = 0;
-	        }
+			if (this.repeats)
+			{
+				if(xP < -width || xP > width)
+				{
+					xP = 0;
+				}
+				
+				if(yP < -height || yP > height)
+				{
+					yP = 0;
+				}
+			}
 	        
 	        xPos += Math.floor(xP);
 	        yPos += Math.floor(yP);
@@ -174,42 +182,48 @@ class ScrollingBitmap extends Sprite
 		cacheWidth = image1.width;
 		cacheHeight = image1.height;
 		
-		if (xPos < -cacheWidth)
+		if (this.repeats)
 		{
-			xPos = xPos % cacheWidth;
-		}
-		
-		if (yPos < -cacheHeight)
-		{
-			yPos = yPos % cacheHeight;
+			if (xPos < -cacheWidth)
+			{
+				xPos = xPos % cacheWidth;
+			}
+			
+			if (yPos < -cacheHeight)
+			{
+				yPos = yPos % cacheHeight;
+			}
 		}
 
 		image1.x = xPos;
 	    image1.y = yPos;
 	        
-	    image2.x = xPos - cacheWidth;
-	    image2.y = yPos;
-	        
-		image3.x = xPos + cacheWidth;
-		image3.y = yPos;
-	        
-		image4.x = xPos - cacheWidth;
-		image4.y = yPos - cacheHeight;
-	        
-		image5.x = xPos;
-		image5.y = yPos - cacheHeight;
-	        
-		image6.x = xPos + cacheWidth;
-		image6.y = yPos - cacheHeight;
-	        
-		image7.x = xPos - cacheWidth;
-		image7.y = yPos + cacheHeight;
-	        
-		image8.x = xPos;
-		image8.y = yPos + cacheHeight;
-	        
-		image9.x = xPos + cacheWidth;
-		image9.y = yPos + cacheHeight;
+		if (this.repeats)
+		{
+			image2.x = xPos - cacheWidth;
+			image2.y = yPos;
+				
+			image3.x = xPos + cacheWidth;
+			image3.y = yPos;
+				
+			image4.x = xPos - cacheWidth;
+			image4.y = yPos - cacheHeight;
+				
+			image5.x = xPos;
+			image5.y = yPos - cacheHeight;
+				
+			image6.x = xPos + cacheWidth;
+			image6.y = yPos - cacheHeight;
+				
+			image7.x = xPos - cacheWidth;
+			image7.y = yPos + cacheHeight;
+				
+			image8.x = xPos;
+			image8.y = yPos + cacheHeight;
+				
+			image9.x = xPos + cacheWidth;
+			image9.y = yPos + cacheHeight;
+		}
 	}
 	
 	public function start()

--- a/com/stencyl/models/scene/layers/BackgroundLayer.hx
+++ b/com/stencyl/models/scene/layers/BackgroundLayer.hx
@@ -29,6 +29,7 @@ class BackgroundLayer extends RegularLayer
 	
 	public var currIndex:Int;
 	public var currTime:Float;
+	public var cacheIndex:Int;
 	
 	public var cacheWidth:Float;
 	public var cacheHeight:Float;
@@ -98,7 +99,7 @@ class BackgroundLayer extends RegularLayer
 		{
 			var scroller = cast(model, ScrollingBackground);
 
-			var img = new ScrollingBitmap(model.img, scroller.xVelocity, scroller.yVelocity, parallaxX, parallaxY, resourceID);
+			var img = new ScrollingBitmap(model.img, scroller.xVelocity, scroller.yVelocity, parallaxX, parallaxY, resourceID, model.repeats);
 			addChild(bgChild = img);
 		}
 		else if(model.repeats)
@@ -197,9 +198,7 @@ class BackgroundLayer extends RegularLayer
 			
 			if (Std.is(bgChild, ScrollingBitmap))
 			{
-				
-				model.img = model.frames[currIndex];
-				var cacheIndex = currIndex;
+				cacheIndex = currIndex;
 				
 				if(model.repeats)
 				{
@@ -209,31 +208,35 @@ class BackgroundLayer extends RegularLayer
 				currIndex = cacheIndex;
 				
 				var b:Bitmap = bgChild.image1;
-				b.bitmapData = model.img;	
+				//b.bitmapData.dispose();
+				b.bitmapData = model.frames[currIndex];	
 
-				b = bgChild.image2;
-				b.bitmapData = bgChild.image1.bitmapData;			
-				
-				b = bgChild.image3;
-				b.bitmapData = bgChild.image1.bitmapData;
-				
-				b = bgChild.image4;
-				b.bitmapData = bgChild.image1.bitmapData;
-				
-				b = bgChild.image5;
-				b.bitmapData = bgChild.image1.bitmapData;
-				
-				b = bgChild.image6;
-				b.bitmapData = bgChild.image1.bitmapData;
-				
-				b = bgChild.image7;
-				b.bitmapData = bgChild.image1.bitmapData;
-				
-				b = bgChild.image8;
-				b.bitmapData = bgChild.image1.bitmapData;
-				
-				b = bgChild.image9;
-				b.bitmapData = bgChild.image1.bitmapData;	
+				if(model.repeats)
+				{
+					b = bgChild.image2;
+					b.bitmapData = model.frames[currIndex];			
+					
+					b = bgChild.image3;
+					b.bitmapData = model.frames[currIndex];	
+					
+					b = bgChild.image4;
+					b.bitmapData = model.frames[currIndex];	
+					
+					b = bgChild.image5;
+					b.bitmapData = model.frames[currIndex];	
+					
+					b = bgChild.image6;
+					b.bitmapData = model.frames[currIndex];	
+					
+					b = bgChild.image7;
+					b.bitmapData = model.frames[currIndex];	
+					
+					b = bgChild.image8;
+					b.bitmapData = model.frames[currIndex];	
+					
+					b = bgChild.image9;
+					b.bitmapData = model.frames[currIndex];		
+				}
 			}
 			
 			else


### PR DESCRIPTION
In this patch, in order to improve the performance of animated scrolling backgrounds which repeat on mobile, I have made several changes to how these work.

Previously, Stencyl rendered these by grabbing the smaller bitmap for the animation and then using the 'drawRepeated' function to render these as larger images. However, this is inconvenient in animated images. It would require that each time the frame changes, a new larger bitmap image be rendered each time. Since bitmap manipulation is done through software rendering on mobile it is slow (as opposed to it being as fast as any other rendering on flash). My changes force the 'ImageBackground', to render these once, when it is created opposed to they being created from the frames in its animation. Therefore, this 'drawRepeated' function doesn't need to be called by the 'BackgroundLayer', and instead it can just grab the already scaled image from the background, saving time and allowing animated backgrounds to be rendered economically.

I have tested on Flash, Adroid and Windows.