### PR TITLE
Sort out exiting fullscreen with wrong scale.

### DIFF
--- a/com/stencyl/Engine.hx
+++ b/com/stencyl/Engine.hx
@@ -431,8 +431,8 @@ class Engine
 			var screenWidth = Lib.current.stage.stageWidth;
 			var screenHeight = Lib.current.stage.stageHeight;
 			
-			root.scaleX = 1.0;
-			root.scaleY = 1.0;
+			root.scaleX = scripts.MyAssets.gameScale;
+			root.scaleY = scripts.MyAssets.gameScale;
 			root.x = 0.0;
 			root.y = 0.0;
 			


### PR DESCRIPTION
Previously if exiting fullscreen, the scale would reset to 1. This change resets it to the initial scale.