### PR TITLE
Zoom behaviour

### DIFF
--- a/com/stencyl/Engine.hx
+++ b/com/stencyl/Engine.hx
@@ -2926,7 +2926,7 @@ class Engine
 		cameraY = Math.min(0, cameraY);
 		
 		// Moving the HUD Layer when zoom is activated
-		if (zoomMultiplier != 1 )
+		if ((zoomMultiplier != 1.0 ) && isHUDZoomable))
 		{
 			hudLayer.x = -Script.getScreenX();
 			hudLayer.y = -Script.getScreenY();
@@ -2940,6 +2940,8 @@ class Engine
 			trace("You cannot set Zoom to less than 1"); 
 			return ;
 		}
+		
+		zooomMultiplier = m;
 		
 		root.scaleX = m * originalScaleX;
 		root.scaleY = m * originalScaleY;

--- a/com/stencyl/models/Actor.hx
+++ b/com/stencyl/models/Actor.hx
@@ -3236,7 +3236,7 @@ class Actor extends Sprite
 			my = myNew;
 		}
 
-                if(isHUD && Engine.engine.isHUDZoomable)
+                if(isHUD && !Engine.engine.isHUDZoomable)
 		{
 			return (mx >= xPos/Engine.engine.zoomMultiplier && 
 		   		my >= yPos/Engine.engine.zoomMultiplier && 


### PR DESCRIPTION
Hi !

I am trying to do a zoom behaviour. and I've tested it and it works quite well.

Basically to zoom x2.   

you do  Engine.engine.setZoom(2)

If you want the HUD to zoom also you do 
Engine.engine.isHUDZoomable =true;
Engine.engine.setZoom(2)

When Hud not zoomed, collisions don't work well ( but HUD aren't meant for collisions in normal games, right ?) but mouse clicks do.

Tested on Flash and Android


Yoplalala