### PR TITLE
More adjustments to rendering

### DIFF
--- a/com/stencyl/models/scene/Layer.hx
+++ b/com/stencyl/models/scene/Layer.hx
@@ -65,13 +65,13 @@ class Layer extends RegularLayer
 	}
 
 	override public function updatePosition(x:Float, y:Float, elapsedTime:Float)
-	{
-		if(scripts.MyAssets.pixelsnap) x = Math.round(x);
-		if(scripts.MyAssets.pixelsnap) y = Math.round(y);
-		
+	{	
 		var xScrolled = Std.int(x * scrollFactorX);
 		var yScrolled = Std.int(y * scrollFactorY);
 
+		if(scripts.MyAssets.pixelsnap) x = Math.round(x);
+		if(scripts.MyAssets.pixelsnap) y = Math.round(y);	
+		
 		overlay.x = -x;
 		overlay.y = -y;
 		bitmapOverlay.x = -x;

--- a/com/stencyl/models/scene/Layer.hx
+++ b/com/stencyl/models/scene/Layer.hx
@@ -66,6 +66,9 @@ class Layer extends RegularLayer
 
 	override public function updatePosition(x:Float, y:Float, elapsedTime:Float)
 	{
+		if(scripts.MyAssets.pixelsnap) x = Math.round(x);
+		if(scripts.MyAssets.pixelsnap) y = Math.round(y);
+		
 		var xScrolled = Std.int(x * scrollFactorX);
 		var yScrolled = Std.int(y * scrollFactorY);
 
@@ -75,8 +78,8 @@ class Layer extends RegularLayer
 		bitmapOverlay.y = -y;
 		tiles.setPosition(-xScrolled, -yScrolled);
 
-		x = Math.round(x);
-		y = Math.round(y); 
+		x = Std.int(x);
+		y = Std.int(y); 
 		
 		this.x = Std.int(x * scrollFactorX);
 		this.y = Std.int(y * scrollFactorY);


### PR DESCRIPTION
Originally, tiles would render correctly. My recent 'fix' made actors render incorrectly, but made tiles render slightly incorrectly. This patch makes both now render correctly so is the best of both worlds.