### PR TITLE
Made Loader Static

### DIFF
--- a/com/stencyl/utils/Kongregate.hx
+++ b/com/stencyl/utils/Kongregate.hx
@@ -4,6 +4,7 @@ package com.stencyl.utils;
 class Kongregate 
 {
 	private static var kongregate:Dynamic;
+	private static var loader:flash.display.Loader;
 	
 	public static function resetStatics():Void
 	{
@@ -30,7 +31,7 @@ class Kongregate
 		}
 			
 		var request = new flash.net.URLRequest(url);
-		var loader = new flash.display.Loader();
+		loader = new flash.display.Loader();
 		loader.contentLoaderInfo.addEventListener(flash.events.Event.COMPLETE, onLoadComplete);
 		loader.load(request);
 		
@@ -41,7 +42,7 @@ class Kongregate
 	{
 		try 
 		{
-			Kongregate.kongregate = cast(e.target, flash.display.Loader).content;
+			Kongregate.kongregate = loader.content;
 			Kongregate.kongregate.services.connect();
 		}
 		

--- a/com/stencyl/utils/Kongregate.hx
+++ b/com/stencyl/utils/Kongregate.hx
@@ -9,6 +9,7 @@ class Kongregate
 	public static function resetStatics():Void
 	{
 		kongregate = null;
+		loader = null;
 	}
 
 	public static function initAPI():Void
@@ -44,6 +45,7 @@ class Kongregate
 		{
 			Kongregate.kongregate = loader.content;
 			Kongregate.kongregate.services.connect();
+			loader = null;
 		}
 		
 		catch(msg:Dynamic) 


### PR DESCRIPTION
Casting "Event" to type "Loader" was not functioning properly, so the loader was made static to access the content of loader in another function.