### PR TITLE
Change wrapping to use difference between coordinates and dimensions

### DIFF
--- a/com/stencyl/models/scene/ScrollingBitmap.hx
+++ b/com/stencyl/models/scene/ScrollingBitmap.hx
@@ -151,7 +151,7 @@ class ScrollingBitmap extends Sprite
 					xP = xP - width;
 				}
 				
-				if(yP <= -height || yP > height)
+				if(yP < -height || yP > height)
 				{
 					yP = yP - height;
 				}

--- a/com/stencyl/models/scene/ScrollingBitmap.hx
+++ b/com/stencyl/models/scene/ScrollingBitmap.hx
@@ -148,12 +148,12 @@ class ScrollingBitmap extends Sprite
 			{
 				if(xP < -width || xP > width)
 				{
-					xP = 0;
+					xP = xP - width;
 				}
 				
-				if(yP < -height || yP > height)
+				if(yP <= -height || yP > height)
 				{
-					yP = 0;
+					yP = yP - height;
 				}
 			}
 	        

--- a/com/stencyl/models/scene/ScrollingBitmap.hx
+++ b/com/stencyl/models/scene/ScrollingBitmap.hx
@@ -148,12 +148,12 @@ class ScrollingBitmap extends Sprite
 			{
 				if(xP < -width || xP > width)
 				{
-					xP = xP - width;
+					xP = xP % width;
 				}
 				
 				if(yP < -height || yP > height)
 				{
-					yP = yP - height;
+					yP = yP % width;
 				}
 			}
 	        


### PR DESCRIPTION
I observed some jitteriness in scrolling backgrounds and decided to look into it. The image coordinates were being set to 0 when they exceeded the image dimensions. It seems like this was a cause of some of the jitter. I modified it to use the difference instead.