### PR TITLE
Fix stacking of image effects

### DIFF
--- a/com/stencyl/behavior/Script.hx
+++ b/com/stencyl/behavior/Script.hx
@@ -2807,7 +2807,7 @@ class Script
 	{
 		if(img != null)
 		{
-			img.img.filters = img.filters.concat([filter]);
+			img.filters = img.filters.concat([filter]);
 		}
 	}
 	
@@ -2815,7 +2815,7 @@ class Script
 	{
 		if(img != null)
 		{
-			img.img.filters = [];
+			img.filters = [];
 		}
 	}
 	


### PR DESCRIPTION
On desktop targets, multiple effects were not stacking on image instances, only the first applied effect showed any changes. Changing the "setFilterForImage" and "clearFiltersForImage" functions to set "img.filters" instead of "img.img.filters" fixed the issue.

Issue Tracker Reference: https://community.stencyl.com/index.php?issue=2055.0